### PR TITLE
adding RUN yarn install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:19 AS ui-build
 WORKDIR /usr/src/app
 COPY . .
 EXPOSE 3000
+RUN yarn install
 RUN yarn webpack build
 
 CMD ["yarn", "webpack-start", "--host", "0.0.0.0", "--port", "3000"]


### PR DESCRIPTION
### Summary

Running docker compose up in the dj-demo folder errored out with:  

> [dj-demo-dj-ui 4/4] RUN yarn webpack build:
#0 0.259 yarn run v1.22.19
#0 0.304 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#0 0.304 error Command "webpack" not found.
------
failed to solve: executor failed running [/bin/sh -c yarn webpack build]: exit code: 1

Included RUN yarn install in the dockerfile

### Test Plan

N/A

### Deployment Plan

N/A
