### PR TITLE
Show dimensions and hyperlink nodes in graph view

### DIFF
--- a/src/app/components/djgraph/__tests__/__snapshots__/DJNode.test.tsx.snap
+++ b/src/app/components/djgraph/__tests__/__snapshots__/DJNode.test.tsx.snap
@@ -37,6 +37,9 @@ exports[`<DJNode /> should render and match the snapshot 1`] = `
       </b>
       :
        
+      <a
+        href="/nodes/shared.dimensions.accounts"
+      />
       <Collapse
         collapsed={true}
         text="columns"


### PR DESCRIPTION
### Summary

This adds the "Show Dimensions" functionality for metrics. It also hyperlinks the node names in the graph view so that you can click and go to that node's page.

https://github.com/DataJunction/dj-ui/assets/43911210/ea20d318-8284-416b-8c39-57e16085d0e3

### Test Plan

Tested the UI locally and ran `yarn test`.

### Deployment Plan

N/A