### PR TITLE
History tab for node page

### DIFF
--- a/src/app/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/__tests__/__snapshots__/index.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
         "DataJunctionAPI": Object {
           "dag": [Function],
           "downstreams": [Function],
+          "history": [Function],
           "lineage": [Function],
           "metric": [Function],
           "namespace": [Function],
@@ -51,6 +52,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
                   Object {
                     "dag": [Function],
                     "downstreams": [Function],
+                    "history": [Function],
                     "lineage": [Function],
                     "metric": [Function],
                     "namespace": [Function],

--- a/src/app/pages/NodePage/NodeHistory.jsx
+++ b/src/app/pages/NodePage/NodeHistory.jsx
@@ -1,0 +1,43 @@
+import { Component } from 'react';
+import { useContext, useEffect, useState } from 'react';
+
+export default function NodeColumnTab({ node, djClient }) {
+  const [history, setHistory] = useState([]);
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await djClient.history('node', node.name);
+      console.log(data);
+      setHistory(data);
+    };
+    fetchData().catch(console.error);
+  }, [djClient, node]);
+  const tableData = history => {
+    return history.map(event => (
+      <tr>
+        <td className="text-start">
+          <span
+            className={`history_type__${event.activity_type} badge node_type`}
+          >
+            {event.activity_type}
+          </span>
+        </td>
+        <td>{event.entity_type}</td>
+        <td>{event.entity_name}</td>
+        <td>{event.created_at}</td>
+      </tr>
+    ));
+  };
+  return (
+    <div className="table-responsive">
+      <table className="card-inner-table table">
+        <thead className="fs-7 fw-bold text-gray-400 border-bottom-0">
+          <th className="text-start">Activity</th>
+          <th>Type</th>
+          <th>Name</th>
+          <th>Timestamp</th>
+        </thead>
+        {tableData(history)}
+      </table>
+    </div>
+  );
+}

--- a/src/app/pages/NodePage/NodeHistory.jsx
+++ b/src/app/pages/NodePage/NodeHistory.jsx
@@ -1,5 +1,4 @@
-import { Component } from 'react';
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function NodeColumnTab({ node, djClient }) {
   const [history, setHistory] = useState([]);

--- a/src/app/pages/NodePage/NodeHistory.jsx
+++ b/src/app/pages/NodePage/NodeHistory.jsx
@@ -23,6 +23,7 @@ export default function NodeColumnTab({ node, djClient }) {
         </td>
         <td>{event.entity_type}</td>
         <td>{event.entity_name}</td>
+        <td>{event.user ? event.user : 'unknown'}</td>
         <td>{event.created_at}</td>
       </tr>
     ));
@@ -34,6 +35,7 @@ export default function NodeColumnTab({ node, djClient }) {
           <th className="text-start">Activity</th>
           <th>Type</th>
           <th>Name</th>
+          <th>User</th>
           <th>Timestamp</th>
         </thead>
         {tableData(history)}

--- a/src/app/pages/NodePage/index.jsx
+++ b/src/app/pages/NodePage/index.jsx
@@ -6,6 +6,7 @@ import NamespaceHeader from '../../components/NamespaceHeader';
 import NodeInfoTab from './NodeInfoTab';
 import NodeColumnTab from './NodeColumnTab';
 import NodeLineage from './NodeGraphTab';
+import NodeHistory from './NodeHistory';
 import DJClientContext from '../../providers/djclient';
 
 export function NodePage() {
@@ -55,6 +56,10 @@ export function NodePage() {
       id: 2,
       name: 'Graph',
     },
+    {
+      id: 3,
+      name: 'History',
+    },
   ];
   //
   //
@@ -68,6 +73,9 @@ export function NodePage() {
       break;
     case 2:
       tabToDisplay = <NodeLineage djNode={node} djClient={djClient} />;
+      break;
+    case 3:
+      tabToDisplay = <NodeHistory node={node} djClient={djClient} />;
       break;
     default:
       tabToDisplay = <NodeInfoTab node={node} />;

--- a/src/app/services/DJService.js
+++ b/src/app/services/DJService.js
@@ -27,6 +27,20 @@ export const DataJunctionAPI = {
     return data;
   },
 
+  history: async function (type, name, offset, limit) {
+    const data = await (
+      await fetch(
+        DJ_URL +
+          '/history/' +
+          type +
+          '/' +
+          name +
+          `/?offset=${offset ? offset : 0}&limit=${limit ? limit : 100}`,
+      )
+    ).json();
+    return data;
+  },
+
   namespace: async function (nmspce) {
     const data = await (
       await fetch(DJ_URL + '/namespaces/' + nmspce + '/')

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -383,6 +383,41 @@ tbody th {
   color: #580076;
 }
 
+.history_type__create {
+  background-color: #ccf7e5 !important;
+  color: #00b368;
+}
+
+.history_type__deactvate {
+  background-color: #a8a8a8 !important;
+  color: #855e5e;
+}
+
+.history_type__activate {
+  background-color: #ccf7e5 !important;
+  color: #00b368;
+}
+
+.history_type__modify {
+  background-color: #ffefd0 !important;
+  color: #a96621;
+}
+
+.history_type__link {
+  background-color: #a8a8a8 !important;
+  color: #855e5e;
+}
+
+.history_type__tag {
+  background-color: #a8a8a8 !important;
+  color: #855e5e;
+}
+
+.history_type__set_attribute {
+  background-color: #a8a8a8 !important;
+  color: #855e5e;
+}
+
 .status__valid {
   color: #00b368;
 }


### PR DESCRIPTION
### Summary

This adds a history tab to the node page that hits the DJ server and lists all history events for `entity_type="node"` and `entity_name={current node name}`.  Right now we only have a single recording of a history event in DJ which is creating source nodes, but as we add more history event recordings throughout the source code, they'll show up in this tab.

https://github.com/DataJunction/dj-ui/assets/43911210/7997d758-1261-4c1a-b603-0d0a26813c11

### Test Plan

`yarn lint:fix` and `yarn build`. Also ran the UI locally.

### Deployment Plan

N/A
