### PR TITLE
add a toggle for displaying compiled SQL

### DIFF
--- a/src/app/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/__tests__/__snapshots__/index.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
     value={
       Object {
         "DataJunctionAPI": Object {
+          "compiledSql": [Function],
           "dag": [Function],
           "downstreams": [Function],
           "history": [Function],
@@ -51,6 +52,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
               <ListNamespacesPage
                 djClient={
                   Object {
+                    "compiledSql": [Function],
                     "dag": [Function],
                     "downstreams": [Function],
                     "history": [Function],

--- a/src/app/components/ToggleSwitch.jsx
+++ b/src/app/components/ToggleSwitch.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const ToggleSwitch = ({ checked, onChange, toggleName }) => (
+  <div>
+    <input
+      id="show-compiled-sql-toggle"
+      type="checkbox"
+      className="checkbox"
+      checked={checked}
+      onChange={e => onChange(e.target.checked)}
+    />
+    <label for="show-compiled-sql-toggle" class="switch"></label> {toggleName}
+  </div>
+);
+
+export default ToggleSwitch;

--- a/src/app/components/ToggleSwitch.jsx
+++ b/src/app/components/ToggleSwitch.jsx
@@ -9,7 +9,8 @@ const ToggleSwitch = ({ checked, onChange, toggleName }) => (
       checked={checked}
       onChange={e => onChange(e.target.checked)}
     />
-    <label for="show-compiled-sql-toggle" class="switch"></label> {toggleName}
+    <label htmlFor="show-compiled-sql-toggle" className="switch"></label>{' '}
+    {toggleName}
   </div>
 );
 

--- a/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -39,12 +39,16 @@ export default function NodeInfoTab({ node }) {
           }}
         >
           <h6 className="mb-0 w-100">Query</h6>
-          <ToggleSwitch
-            id="toggleSwitch"
-            checked={checked}
-            onChange={() => setChecked(toggle)}
-            toggleName="Show Compiled SQL"
-          />
+          {['metric', 'dimension', 'transform'].indexOf(node?.type) > -1 ? (
+            <ToggleSwitch
+              id="toggleSwitch"
+              checked={checked}
+              onChange={() => setChecked(toggle)}
+              toggleName="Show Compiled SQL"
+            />
+          ) : (
+            <></>
+          )}
           <SyntaxHighlighter language="sql" style={foundation}>
             {checked
               ? format(compiledSQL, {

--- a/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -1,4 +1,4 @@
-import { Component, useState, useContext, useEffect } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
 import sql from 'react-syntax-highlighter/dist/esm/languages/hljs/sql';
@@ -26,7 +26,7 @@ export default function NodeInfoTab({ node }) {
       }
     };
     fetchData().catch(console.error);
-  }, [node]);
+  }, [node, djClient]);
   function toggle(value) {
     return !value;
   }

--- a/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -1,18 +1,36 @@
-import { Component } from 'react';
+import { Component, useState, useContext, useEffect } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
 import sql from 'react-syntax-highlighter/dist/esm/languages/hljs/sql';
 import { format } from 'sql-formatter';
-
 import NodeStatus from './NodeStatus';
 import ListGroupItem from '../../components/ListGroupItem';
+import ToggleSwitch from '../../components/ToggleSwitch';
+import DJClientContext from '../../providers/djclient';
 
 SyntaxHighlighter.registerLanguage('sql', sql);
 foundation.hljs['padding'] = '2rem';
 
-export default class NodeInfoTab extends Component {
-  nodeTags = this.props.node?.tags.map(tag => <div>{tag}</div>);
-  queryDiv = this.props.node?.query ? (
+export default function NodeInfoTab({ node }) {
+  const [compiledSQL, setCompiledSQL] = useState('');
+  const [checked, setChecked] = useState(false);
+  const nodeTags = node?.tags.map(tag => <div>{tag}</div>);
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await djClient.compiledSql(node.name);
+      if (data.sql) {
+        setCompiledSQL(data.sql);
+      } else {
+        setCompiledSQL('/* Ran into an issue while generating compiled SQL */');
+      }
+    };
+    fetchData().catch(console.error);
+  }, [node]);
+  function toggle(value) {
+    return !value;
+  }
+  const queryDiv = node?.query ? (
     <div className="list-group-item d-flex">
       <div className="d-flex gap-2 w-100 justify-content-between py-3">
         <div
@@ -21,15 +39,30 @@ export default class NodeInfoTab extends Component {
           }}
         >
           <h6 className="mb-0 w-100">Query</h6>
+          <ToggleSwitch
+            id="toggleSwitch"
+            checked={checked}
+            onChange={() => setChecked(toggle)}
+            toggleName="Show Compiled SQL"
+          />
           <SyntaxHighlighter language="sql" style={foundation}>
-            {format(this.props.node?.query, {
-              language: 'spark',
-              tabWidth: 2,
-              keywordCase: 'upper',
-              denseOperators: true,
-              logicalOperatorNewline: 'before',
-              expressionWidth: 10,
-            })}
+            {checked
+              ? format(compiledSQL, {
+                  language: 'spark',
+                  tabWidth: 2,
+                  keywordCase: 'upper',
+                  denseOperators: true,
+                  logicalOperatorNewline: 'before',
+                  expressionWidth: 10,
+                })
+              : format(node?.query, {
+                  language: 'spark',
+                  tabWidth: 2,
+                  keywordCase: 'upper',
+                  denseOperators: true,
+                  logicalOperatorNewline: 'before',
+                  expressionWidth: 10,
+                })}
           </SyntaxHighlighter>
         </div>
       </div>
@@ -37,51 +70,43 @@ export default class NodeInfoTab extends Component {
   ) : (
     <></>
   );
+  return (
+    <div className="list-group align-items-center justify-content-between flex-md-row gap-2">
+      <ListGroupItem label="Description" value={node?.description} />
+      <div className="list-group-item d-flex">
+        <div className="d-flex gap-2 w-100 justify-content-between py-3">
+          <div>
+            <h6 className="mb-0 w-100">Version</h6>
 
-  render() {
-    return (
-      <div className="list-group align-items-center justify-content-between flex-md-row gap-2">
-        <ListGroupItem
-          label="Description"
-          value={this.props.node?.description}
-        />
-        <div className="list-group-item d-flex">
-          <div className="d-flex gap-2 w-100 justify-content-between py-3">
-            <div>
-              <h6 className="mb-0 w-100">Version</h6>
-
-              <p className="mb-0 opacity-75">
-                <span
-                  className="rounded-pill badge bg-secondary-soft"
-                  style={{ marginLeft: '0.5rem', fontSize: '100%' }}
-                >
-                  {this.props.node?.version}
-                </span>
-              </p>
-            </div>
-            <div>
-              <h6 className="mb-0 w-100">Status</h6>
-              <p className="mb-0 opacity-75">
-                <NodeStatus node={this.props.node} />
-              </p>
-            </div>
-            <div>
-              <h6 className="mb-0 w-100">Mode</h6>
-              <p className="mb-0 opacity-75">
-                <span className="status">{this.props.node?.mode}</span>
-              </p>
-            </div>
-            <div>
-              <h6 className="mb-0 w-100">Tags</h6>
-              <p className="mb-0 opacity-75">{this.nodeTags}</p>
-            </div>
+            <p className="mb-0 opacity-75">
+              <span
+                className="rounded-pill badge bg-secondary-soft"
+                style={{ marginLeft: '0.5rem', fontSize: '100%' }}
+              >
+                {node?.version}
+              </span>
+            </p>
+          </div>
+          <div>
+            <h6 className="mb-0 w-100">Status</h6>
+            <p className="mb-0 opacity-75">
+              <NodeStatus node={node} />
+            </p>
+          </div>
+          <div>
+            <h6 className="mb-0 w-100">Mode</h6>
+            <p className="mb-0 opacity-75">
+              <span className="status">{node?.mode}</span>
+            </p>
+          </div>
+          <div>
+            <h6 className="mb-0 w-100">Tags</h6>
+            <p className="mb-0 opacity-75">{nodeTags}</p>
           </div>
         </div>
-        {this.queryDiv}
-        <div className="list-group-item d-flex">
-          {this.props.node?.primary_key}
-        </div>
       </div>
-    );
-  }
+      {queryDiv}
+      <div className="list-group-item d-flex">{node?.primary_key}</div>
+    </div>
+  );
 }

--- a/src/app/services/DJService.js
+++ b/src/app/services/DJService.js
@@ -65,6 +65,11 @@ export const DataJunctionAPI = {
 
   lineage: async function (node) {},
 
+  compiledSql: async function (node) {
+    const data = await (await fetch(DJ_URL + `/sql/${node}/`)).json();
+    return data;
+  },
+
   dag: async function (namespace = 'default') {
     const edges = [];
     const data = await (await fetch(DJ_URL + '/nodes/')).json();

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -603,3 +603,36 @@ pre {
   /*width:100%;*/
   /*max-width: fit-content;*/
 }
+
+.switch { 
+  position : relative ;
+  display : inline-block;
+  width : 40px;
+  height : 20px;
+  background-color: #eee;
+  border-radius: 20px;
+  vertical-align: middle;
+}
+
+.switch::after {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: white;
+  top: 1px;
+  left: 1px;
+  transition: all 0.3s;
+}
+
+.checkbox:checked + .switch::after {
+  left : 20px; 
+}
+.checkbox:checked + .switch {
+  background-color: #7983ff;
+}
+
+.checkbox { 
+  display : none;
+}


### PR DESCRIPTION
### Summary

This adds a toggle for showing the compile result for the SQL for a given node. This toggle is only available for metric, dimension, or transform nodes. Source nodes don't have any SQL and cube nodes don't have an "uncompiled" version of SQL so the SQL that's shown is already compiled.

https://github.com/DataJunction/dj-ui/assets/43911210/689eba7a-cfdc-4125-9bd0-30c81756f0de

### Test Plan

Tested locally.

### Deployment Plan

N/A
